### PR TITLE
Fix Annotate PR step in update-parks workflow

### DIFF
--- a/.github/workflows/update-parks.yml
+++ b/.github/workflows/update-parks.yml
@@ -28,7 +28,10 @@ jobs:
       - run: npm ci
       - run: |
           set -uo pipefail
-          outfile="${{ runner.temp }}/output.txt"
+          # Must live inside the workspace: add-annotations-github-action reads
+          # "$GITHUB_WORKSPACE/$linter_output_path", so the path it is given has
+          # to be workspace-relative. Gitignored so it is never committed.
+          outfile="${{ github.workspace }}/parks-annotations.json"
 
           # Run updater; capture stdout/stderr and the exit code separately so we
           # can still emit per-record annotations but fail the job if the script
@@ -63,8 +66,8 @@ jobs:
           fi
         env:
           NPS_API_KEY: ${{ secrets.NPS_API_KEY }}
-      - run: cat "${{ runner.temp }}/output.txt"
-      - run: jq . "${{ runner.temp }}/output.txt"
+      - run: cat "${{ github.workspace }}/parks-annotations.json"
+      - run: jq . "${{ github.workspace }}/parks-annotations.json"
       - run: npm run lint-fix
       - name: Commit changes
         id: commit_changes
@@ -91,7 +94,7 @@ jobs:
         with:
           mode: json
           check_name: Park Metadata Updater
-          linter_output_path: ${{ runner.temp }}/output.txt
+          linter_output_path: parks-annotations.json
           commit_sha: ${{ steps.commit_changes.outputs.commit_hash }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -344,3 +344,6 @@ poetry.toml
 pyrightconfig.json
 
 # End of https://www.toptal.com/developers/gitignore/api/node,python,macos
+
+# Transient annotation payload written by the update-parks workflow
+parks-annotations.json

--- a/.prettierignore
+++ b/.prettierignore
@@ -4,3 +4,4 @@ coverage
 .mypy_cache
 .pytest_cache
 venv
+parks-annotations.json


### PR DESCRIPTION
Fixes the `Annotate PR` step failure in [run 29091067235](https://github.com/jamescurtin/nps_passport_tracker/actions/runs/29091067235/job/86356253140).

## Root cause

`pytorch/add-annotations-github-action` resolves its input as `${GITHUB_WORKSPACE}/${linter_output_path}` ([main.ts#L106](https://github.com/pytorch/add-annotations-github-action/blob/8436d20d95a47566529672c4cb464770a1ec0b49/src/main.ts#L106)) — it unconditionally prefixes the workspace, so `linter_output_path` must be **workspace-relative**.

The workflow passed the absolute `${{ runner.temp }}/output.txt`. `runner.temp` (`/home/runner/work/_temp`) is outside the workspace, so the action concatenated the two into:

```
/home/runner/work/nps_passport_tracker/nps_passport_tracker//home/runner/work/_temp/output.txt
```

and failed with `ENOENT`.

## Why it looked intermittent

The step is gated on `changes_detected == 'true'`, so it only runs when `parks.json` actually changed. Every run that produced a diff failed; every no-op run passed:

| Run | parks.json changed | Result |
|---|---|---|
| 29091067235 | yes | failure |
| 28747510036 | no | success |
| 28747351942 | yes | failure |
| 28726337552 | yes | failure |

## Fix

Write the annotation payload to `parks-annotations.json` inside the workspace and pass the relative path. Two steps run after that file is written, and both had to be taught to skip it:

- `git-auto-commit-action` defaults to `file_pattern: '.'` → `git add .`, so the artifact is added to `.gitignore` (ignored paths are not staged).
- `npm run lint-fix` runs `prettier --write .`, which does not read `.gitignore`, so the artifact is added to `.prettierignore`.

## Verification

- Replayed the action's path-resolution logic against the old input and reproduced the CI error string byte-for-byte, double slash included.
- Replayed it against the new input: file is found and parsed into 1 annotation.
- Regenerated the payload with the workflow's exact `jq` block; `jq .` (the workflow's gate step) validates it.
- `git add --dry-run .` with the artifact present: 0 occurrences staged.
- `npm run lint-check` with the artifact present: passes, prettier does not match it.
